### PR TITLE
Remove unsupported deps - (fbgemm-gpu-nightly)

### DIFF
--- a/torchbenchmark/models/torchrec_dlrm/requirements.txt
+++ b/torchbenchmark/models/torchrec_dlrm/requirements.txt
@@ -1,3 +1,3 @@
 torchrec-nightly
-fbgemm-gpu-nightly
+# fbgemm-gpu-nightly
 pyre-extensions


### PR DESCRIPTION
Remove unsupported deps - `fbgemm-gpu-nightly` is not supported on arm CPUs and causes a hard crash in install.py script:
```
Error for /Users/mps-local/Desktop/actions-runner/_work/pytorch/pytorch/benchmark/torchbenchmark/models/torchrec_dlrm:
---------------------------------------------------------------------------
ERROR: Could not find a version that satisfies the requirement fbgemm-gpu-nightly (from versions: none)
ERROR: No matching distribution found for fbgemm-gpu-nightly
Traceback (most recent call last):
  File "/Users/mps-local/Desktop/actions-runner/_work/pytorch/pytorch/benchmark/torchbenchmark/models/torchrec_dlrm/install.py", line 10, in <module>
    pip_install_requirements()
  File "/Users/mps-local/Desktop/actions-runner/_work/pytorch/pytorch/benchmark/torchbenchmark/models/torchrec_dlrm/install.py", line 7, in pip_install_requirements
    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
  File "/Users/mps-local/Desktop/actions-runner/_work/_temp/conda_environment_4358628906/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/Users/mps-local/Desktop/actions-runner/_work/_temp/conda_environment_4358628906/bin/python', '-m', 'pip', 'install', '-q', '-r', 'requirements.txt']' returned non-zero exit status 1.
---------------------------------------------------------------------------
```